### PR TITLE
Improve display of screenshots in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,45 +9,82 @@ tool. LUX will track, identify, analyse your leads and give the visitors some im
 like showing relevant information at the right time.
 LUX will not set any cookies.
 
-## Screenshots
-
-TYPO3 dashboard (for TYPO3 with package "typo3/cms-dashboard"):\
-\
-![Example TYPO3 dashboard](Documentation/Images/screenshot_typo3dashboard.png "TYPO3 Dashboard")
-
-Example dashboards:\
-\
-![Example dashboard1](Documentation/Images/screenshot_dashboard.png "Dashboard1")
-
-![Example dashboard2](Documentation/Images/screenshot_analysis_dashboard.png "Dashboard2")
-
-Example leadlist:\
-\
-![Leadlist](Documentation/Images/screenshot_list.png "Leadlist")
-
-Show some details:\
-\
-![Some Details](Documentation/Images/screenshot_list2.png "Some details")
-
-Show relevant information in page view:\
-\
-![Relevant information in page view](Documentation/Images/screenshot_pageoverview.png "Page Overview")
-
-Workflow - Define your own trigger(s) and combine them via AND or OR (Enterprise version only):\
-\
-![Workflow trigger](Documentation/Images/screenshot_workflow_trigger.png "Workflow Trigger")
-
-Workflow - Do one or more Actions if a trigger is activated (Enterprise version only):\
-\
-![Workflow action](Documentation/Images/screenshot_workflow_action.png "Workflow action")
-
-Ask for the visitors email-address when he/she wants to download an asset:\
-\
-![Email 4 Link](Documentation/Images/screenshot_email4link.png "E-Mail for Link")
-
-... with a CK editor plugin:\
-\
-![Email for Link with CKEditor](Documentation/Images/screenshot_email4link_ckeditor_plugin.png "with CKeditor")
+<table>
+    <tr>
+        <th colspan="2" align="center">Screenshots</th>
+    </tr>
+    <tr>
+        <th colspan="2">TYPO3 dashboard (for TYPO3 with package <code>typo3/cms-dashboard</code>)</th>
+    </tr>
+    <tr>
+        <td align="center" colspan="2">
+            <img alt="" width="600" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_typo3dashboard.png">
+        </td>
+    </tr>
+    <tr>
+        <th colspan="2">Example dashboards</th>
+    <tr>
+    </tr>
+        <td align="center">
+            <img alt="" width="400" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_dashboard.png">
+        </td>
+        <td align="center">
+            <img alt="" width="400" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_analysis_dashboard.png">
+        </td>
+    </tr>
+    <tr>
+        <th>Leadlist</th>
+        <th>Lead details</th>
+    </tr>
+    <tr>
+        <td align="center">
+            <img alt="" width="400" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_list.png">
+        </td>
+        <td align="center">
+            <img alt="" width="400" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_list2.png">
+        </td>
+    </tr>
+    <tr>
+        <th colspan="2">Show relevant information in page view</th>
+    </tr>
+    <tr>
+        <td align="center" colspan="2">
+            <img alt="" width="600" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_pageoverview.png">
+        </td>
+    </tr>
+    <tr>
+        <td align="center">
+            <strong>Workflow</strong><br/>
+            Define your own trigger(s) and combine them via AND or OR<br/>
+            <i>(Enterprise version only)</i>
+        </td>
+        <td align="center">
+            <strong>Workflow</strong><br/>
+            Do one or more Actions if a trigger is activated<br/>
+            <i>(Enterprise version only)</i>
+        </td>
+    </tr>
+    <tr>
+        <td align="center">
+            <img alt="" width="400" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_workflow_trigger.png">
+        </td>
+        <td align="center">
+            <img alt="" width="400" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_workflow_action.png">
+        </td>
+    </tr>
+    <tr>
+        <th>Ask for the visitors email-address when he/she wants to download an asset</th>
+        <th>...with a CK editor plugin</th>
+    </tr>
+    <tr>
+        <td align="center">
+            <img alt="" width="400" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_email4link.png">
+        </td>
+        <td align="center">
+            <img alt="" width="400" src="https://github.com/in2code-de/lux/blob/master/Documentation/Images/screenshot_email4link_ckeditor_plugin.png">
+        </td>
+    </tr>
+</table>
 
 ## Documentation
 


### PR DESCRIPTION
The screenshots in the README take up a large amount of space.

This alignment using tables still uses some amount, but it is significantly less than before. To view the full size variants, the images still can be clicked.

**Preview:** https://github.com/in2code-de/lux/blob/feature/readme-screenshots/readme.md