### PR TITLE
[TASK] Fix orientation of enterprise link in page module

### DIFF
--- a/Resources/Private/Templates/Backend/PageOverview.html
+++ b/Resources/Private/Templates/Backend/PageOverview.html
@@ -1,7 +1,7 @@
 <f:if condition="{visitors}">
     <lux:condition.isLuxenterpriseExtensionActivated>
         <f:else>
-            <a href="https://www.in2code.de/produkte/lux-typo3-marketing-automation/" class="lux_poweredby" style="position:absolute;right:38px;font-weight:bold;">
+            <a href="https://www.in2code.de/produkte/lux-typo3-marketing-automation/" class="lux_poweredby" style="float:right;font-weight:bold;">
                 <img src="{f:uri.resource(path:'Icons/star.svg',extensionName:'lux')}" alt="Lux enterprise" width="20" height="20" style="vertical-align:bottom;" />
                 Go enterprise
             </a>


### PR DESCRIPTION
The link "Go enterprise" in the page module is set with absolute position and will scroll with the page module. 

## Expected behavior
The link remains in its parent element. 

## Steps to Reproduce
1. Install lux extension without lux enterprise
2. Log into the TYPO3 backend
3. Go to the page module
4. Scroll down the page module (if possible)