### PR TITLE
Register custom link attributes to the CKEditor5 schema 

### DIFF
--- a/Resources/Public/JavaScript/Static/CkEditorPlugins/luxEmail4Link/email4link/editing.js
+++ b/Resources/Public/JavaScript/Static/CkEditorPlugins/luxEmail4Link/email4link/editing.js
@@ -12,6 +12,9 @@ export default class Email4LinkEditing extends Core.Plugin {
 
   _defineConverters() {
     const conversion = this.editor.conversion;
+    const schema = this.editor.model.schema;
+
+    schema.extend('$text', { allowAttributes: ['sendEmail', 'emailTitle', 'emailText'] })
 
     conversion.for('downcast').attributeToElement({
       model: 'sendEmail',

--- a/Resources/Public/JavaScript/Static/CkEditorPlugins/luxEmail4Link/email4link/editing.js
+++ b/Resources/Public/JavaScript/Static/CkEditorPlugins/luxEmail4Link/email4link/editing.js
@@ -23,7 +23,7 @@ export default class Email4LinkEditing extends Core.Plugin {
     });
     editor.conversion.for('upcast').elementToAttribute({
       view: { name: 'a', attributes: { 'data-lux-email4link-sendemail': true } },
-      model: { key: 'sendEmail', value: (viewElement) => viewElement.getAttribute('data-lux-send-email') }
+      model: { key: 'sendEmail', value: (viewElement) => viewElement.getAttribute('data-lux-email4link-sendemail') }
     });
 
     conversion.for('downcast').attributeToElement({
@@ -48,8 +48,8 @@ export default class Email4LinkEditing extends Core.Plugin {
       }
     });
     editor.conversion.for('upcast').elementToAttribute({
-      view: { name: 'a', attributes: { 'data-lux-email4link-sendemail': true } },
-      model: { key: 'email4linkText', value: (viewElement) => viewElement.getAttribute('data-lux-email4link-text') }
+      view: { name: 'a', attributes: { 'data-lux-email4link-text': true } },
+      model: { key: 'emailText', value: (viewElement) => viewElement.getAttribute('data-lux-email4link-text') }
     });
   }
 }


### PR DESCRIPTION
Model attribute will only be preserved and allowed
when they are registered to the CKEditor5 schema.

This is a workaround for https://forge.typo3.org/issues/99738

See https://forge.typo3.org/issues/99738#note-8 for more information.