### PR TITLE
Enrich fingerprint hash with IP address

### DIFF
--- a/Classes/Domain/Model/Fingerprint.php
+++ b/Classes/Domain/Model/Fingerprint.php
@@ -52,8 +52,10 @@ class Fingerprint extends AbstractModel
         }
         if (strlen($value) === 33) {
             $this->setType(self::TYPE_STORAGE);
+            $this->value = $value;
+        } else {
+            $this->value = hash('sha256', $value . IpUtility::getIpAddress());
         }
-        $this->value = hash('sha256', $value . IpUtility::getIpAddress());
         return $this;
     }
 

--- a/Classes/Domain/Model/Fingerprint.php
+++ b/Classes/Domain/Model/Fingerprint.php
@@ -7,6 +7,7 @@ use In2code\Lux\Domain\Service\SiteService;
 use In2code\Lux\Exception\FingerprintMustNotBeEmptyException;
 use In2code\Lux\Utility\BackendUtility;
 use In2code\Lux\Utility\EnvironmentUtility;
+use In2code\Lux\Utility\IpUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WhichBrowser\Parser;
 
@@ -52,7 +53,7 @@ class Fingerprint extends AbstractModel
         if (strlen($value) === 33) {
             $this->setType(self::TYPE_STORAGE);
         }
-        $this->value = $value;
+        $this->value = hash('sha256', $value . IpUtility::getIpAddress());
         return $this;
     }
 

--- a/Tests/Unit/Domain/Model/FingerprintTest.php
+++ b/Tests/Unit/Domain/Model/FingerprintTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace In2code\Lux\Tests\Unit\Domain\Model;
+
+use In2code\Lux\Domain\Model\Fingerprint;
+use In2code\Lux\Tests\Helper\TestingHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * @coversDefaultClass \In2code\Lux\Domain\Model\Fingerprint
+ */
+class FingerprintTest extends UnitTestCase
+{
+    protected bool $resetSingletonInstances = true;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestingHelper::setDefaultConstants();
+    }
+
+    /**
+     * @return void
+     * @covers ::setValue
+     */
+    public function testFingerprintType(): void
+    {
+        $fingerprint = new Fingerprint();
+
+        $fingerprint->setValue(random_bytes(32));
+        self::assertEquals($fingerprint->getType(), Fingerprint::TYPE_FINGERPRINT);
+
+        $fingerprint->setValue(random_bytes(33));
+        self::assertEquals($fingerprint->getType(), Fingerprint::TYPE_STORAGE);
+    }
+
+    /**
+     * @return void
+     * @covers ::setValue
+     */
+    public function testAssertSameHashesWithSameIps(): void
+    {
+        $fingerprint = new Fingerprint();
+        $identifier = bin2hex(random_bytes(16));
+
+        $fingerprint->setValue($identifier);
+        $value1 = $fingerprint->getValue();
+
+        $fingerprint->setValue($identifier);
+        $value2 = $fingerprint->getValue();
+
+        self::assertEquals($value1, $value2);
+    }
+
+    /**
+     * @return void
+     * @covers ::setValue
+     */
+    public function testAssertDifferentHashesWithDifferentIps(): void
+    {
+        $fingerprint = new Fingerprint();
+        $identifier = bin2hex(random_bytes(16));
+
+        GeneralUtility::setIndpEnv('REMOTE_ADDR', '192.168.178.1');
+        $fingerprint->setValue($identifier);
+
+        $value1 = $fingerprint->getValue();
+
+        GeneralUtility::setIndpEnv('REMOTE_ADDR', '192.168.178.16');
+        $fingerprint->setValue($identifier);
+
+        $value2 = $fingerprint->getValue();
+
+        self::assertNotEquals($value1, $value2);
+    }
+}

--- a/Tests/Unit/Domain/Model/FingerprintTest.php
+++ b/Tests/Unit/Domain/Model/FingerprintTest.php
@@ -60,7 +60,7 @@ class FingerprintTest extends UnitTestCase
     public function testAssertDifferentHashesWithDifferentIps(): void
     {
         $fingerprint = new Fingerprint();
-        $identifier = bin2hex(random_bytes(16));
+        $identifier = random_bytes(32);
 
         GeneralUtility::setIndpEnv('REMOTE_ADDR', '192.168.178.1');
         $fingerprint->setValue($identifier);
@@ -73,5 +73,20 @@ class FingerprintTest extends UnitTestCase
         $value2 = $fingerprint->getValue();
 
         self::assertNotEquals($value1, $value2);
+    }
+
+    /**
+     * @return void
+     * @covers ::setValue
+     */
+    public function testAssertNoHashingForStorageType(): void
+    {
+        $fingerprint = new Fingerprint();
+        $identifier = random_bytes(33);
+
+        $fingerprint->setValue($identifier);
+        $value = $fingerprint->getValue();
+
+        self::assertEquals($identifier, $value);
     }
 }


### PR DESCRIPTION
Tracking purely based on device fingerprinting lead to some issues, namely mobile browsers working more towards sandboxing requests so that device hashes end up being the same across the same line of devices. This makes individual tracking unreliable and in the case of Lux leads to some leads that contain several different people in them.

This change enriches the fingerprint with the users IP address and hashes it again, leading to a more unique identification value.

Negative impact of this change:
* **(BREAKING)** Previously identified users can't be identified anymore, as the calculated fingerprint value has changed.
* Compared to before, we now create _more_ unique users than before, as IP addresses (usually) change on the regular for home connections or when switching wi-fi/cellular networks.