### PR TITLE
[DOC] Fix docs for Email4Link RTE integration

### DIFF
--- a/Documentation/Technical/Identification/Index.md
+++ b/Documentation/Technical/Identification/Index.md
@@ -305,14 +305,13 @@ imports:
     - { resource: "EXT:rte_ckeditor/Configuration/RTE/Editor/Plugins.yaml" }
 
 editor:
-  externalPlugins:
-    luxEmail4Link:
-      resource: 'EXT:lux/Resources/Public/JavaScript/Static/CkEditorPlugins/luxEmail4Link/plugin.js'
-
   config:
 
     extraAllowedContent: 'a[data-*];'
     contentsCss: ['EXT:lux/Resources/Public/Css/Modules.min.css']
+
+    importModules:
+      - 'EXT:lux/Resources/Public/JavaScript/Static/CkEditorPlugins/luxEmail4Link/plugin.js'
 
     toolbarGroups:
       - { name: 'styles', groups: [ 'styles' ] }


### PR DESCRIPTION
The configuration for CKEditor5 has changed with TYPO3 v12