### PR TITLE
Add event listener to handle LuxletterLinkLuxIdentificationEvent

### DIFF
--- a/Classes/Hooks/LuxletterLinkLuxIdentificationHandler.php
+++ b/Classes/Hooks/LuxletterLinkLuxIdentificationHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+namespace In2code\Lux\Hooks;
+
+use In2code\Lux\Utility\CookieUtility;
+use In2code\Luxletter\Events\LuxletterLinkLuxIdentificationEvent;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+#[AsEventListener(
+    identifier: 'lux/handle-luxletter-link-lux-identification',
+    event: LuxletterLinkLuxIdentificationEvent::class
+)]
+class LuxletterLinkLuxIdentificationHandler
+{
+    public function __invoke(LuxletterLinkLuxIdentificationEvent $event)
+    {
+        if ($event->isIdentification()) {
+            $link = $event->getLink();
+            CookieUtility::setCookie('luxletterlinkhash', $link['hash']);
+        }
+    }
+}


### PR DESCRIPTION
In order to clear up https://github.com/in2code-de/luxletter/issues/94 I'm adding an event listener for that specific event to Lux, to handle tracking cookie setting.

I was not sure where to place the listener class so if you have another suggestion, please feel free to tell me where to put it instead.