### PR TITLE
[BUGFIX] Qualify referrer column in referrer-domain queries

### DIFF
--- a/Classes/Domain/Repository/PagevisitRepository.php
+++ b/Classes/Domain/Repository/PagevisitRepository.php
@@ -414,11 +414,11 @@ class PagevisitRepository extends AbstractRepository
     {
         /** @var SiteService $siteService */
         $siteService = GeneralUtility::makeInstance(SiteService::class);
-        $sql = 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(referrer, \'://\', -1), \'/\', 1) as referrer_domain, COUNT(*) as total_pagevisits';
+        $sql = 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pv.referrer, \'://\', -1), \'/\', 1) as referrer_domain, COUNT(*) as total_pagevisits';
         $sql .= ' FROM ' . Pagevisit::TABLE_NAME . ' pv';
         $sql .= ' WHERE pv.deleted = 0 and pv.hidden = 0';
         $sql .=  ' AND pv.referrer != \'\'';
-        $sql .= ' AND referrer NOT REGEXP "' . $siteService->getAllDomainsForWhereClause() . '"';
+        $sql .= ' AND pv.referrer NOT REGEXP "' . $siteService->getAllDomainsForWhereClause() . '"';
         $sql .= $this->extendWhereClauseWithFilterSearchterms($filter, 'pv', 'referrer');
         $sql .= $this->extendWhereClauseWithFilterTime($filter, true, 'pv');
         $sql .= $this->extendWhereClauseWithFilterSite($filter);
@@ -429,7 +429,7 @@ class PagevisitRepository extends AbstractRepository
 
     protected function getIdentifiedVisitorsPerReferrerSql(FilterDto $filter): string
     {
-        $sql = 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(referrer, \'://\', -1), \'/\', 1) as referrer_domain, COUNT(DISTINCT pv.visitor) as identified_visitor_count';
+        $sql = 'SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(pv.referrer, \'://\', -1), \'/\', 1) as referrer_domain, COUNT(DISTINCT pv.visitor) as identified_visitor_count';
         $sql .= ' FROM ' . Pagevisit::TABLE_NAME . ' pv';
         $sql .= ' INNER JOIN ' . Visitor::TABLE_NAME . ' v ON pv.visitor=v.uid AND v.identified=1 AND v.hidden=0 AND v.deleted=0';
         $sql .= ' WHERE pv.deleted = 0 and pv.hidden = 0 AND pv.referrer != \'\'';


### PR DESCRIPTION
[Claude Code]
## Problem

Das Sources-Analysemodul (`LuxAnalysis/Analysis/sources`) stürzt mit folgendem Fehler ab:

`#1052 An exception occurred while executing a query: Column 'referrer' in SELECT is ambiguous`

Der Fehler tritt auf, sobald die Tabelle `tx_lux_domain_model_visitor` noch eine alte `referrer`-Spalte enthält (Überbleibsel aus älteren LUX-Versionen — Schema-Migrationen entfernen veraltete Spalten nie automatisch).

## Ursache

`getIdentifiedVisitorsPerReferrerSql()` verknüpft `tx_lux_domain_model_pagevisit` per `INNER JOIN` mit `tx_lux_domain_model_visitor`, referenziert `referrer` im `SELECT` aber **unqualifiziert**:

```sql
SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(referrer, '://', -1), '/', 1) AS referrer_domain, ...
FROM tx_lux_domain_model_pagevisit pv
INNER JOIN tx_lux_domain_model_visitor v ON pv.visitor = v.uid AND ...
```

Haben beide Tabellen eine referrer-Spalte, kann MySQL die Spalte nicht mehr eindeutig auflösen und das gesamte Modul bricht ab.

## Fix

Die Spalte wird in beiden Referrer-Domain-Queries mit dem Alias pv. qualifiziert, sodass sie unabhängig von veralteten Spalten auf verknüpften Tabellen immer auf tx_lux_domain_model_pagevisit verweist.

Geändert in Classes/Domain/Repository/PagevisitRepository.php (3 Zeilen):

- getIdentifiedVisitorsPerReferrerSql() — SUBSTRING_INDEX(referrer, …) → SUBSTRING_INDEX(pv.referrer, …) (der eigentliche Absturz, JOIN pagevisit ↔ visitor)
- getPageVisitsPerReferrerSql() — SELECT-Ausdruck und NOT REGEXP-Klausel ebenfalls auf pv.referrer (Konsistenz/Absicherung; dort kein JOIN, daher heute kein Absturz)

## Test

- PHP-Lint fehlerfrei
- Die zuvor fehlschlagende Query läuft nach dem Fix ohne Ambiguitätsfehler durch