### PR TITLE
Company Size Filter SQL prüfen

### DIFF
--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -343,7 +343,7 @@ abstract class AbstractRepository extends Repository
             if ($table !== '') {
                 $table .= '.';
             }
-            $sql .= ' and ' . $table . 'size_class = ' . $filter->getSizeClass();
+            $sql .= ' and ' . $table . 'size_class = ' . (int)$filter->getSizeClass();
         }
         return $sql;
     }
@@ -355,7 +355,7 @@ abstract class AbstractRepository extends Repository
             if ($table !== '') {
                 $table .= '.';
             }
-            $sql .= ' and ' . $table . 'revenue_class = ' . $filter->getRevenueClass();
+            $sql .= ' and ' . $table . 'revenue_class = ' . (int)$filter->getRevenueClass();
         }
         return $sql;
     }

--- a/Tests/Unit/Domain/Repository/AbstractRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/AbstractRepositoryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace In2code\Lux\Tests\Unit\Domain\Repository;
+
+use In2code\Lux\Domain\Model\Transfer\FilterDto;
+use In2code\Lux\Domain\Repository\AbstractRepository;
+use In2code\Lux\Tests\Unit\Fixtures\Domain\Repository\AbstractRepositoryFixture;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * @coversDefaultClass \In2code\Lux\Domain\Repository\AbstractRepository
+ */
+#[CoversClass(AbstractRepository::class)]
+#[CoversMethod(AbstractRepository::class, 'extendWhereClauseWithFilterSizeClass')]
+#[CoversMethod(AbstractRepository::class, 'extendWhereClauseWithFilterRevenueClass')]
+class AbstractRepositoryTest extends UnitTestCase
+{
+    protected bool $resetSingletonInstances = true;
+
+    protected AbstractRepositoryFixture $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new AbstractRepositoryFixture();
+    }
+
+    public static function sizeAndRevenueClassDataProvider(): array
+    {
+        return [
+            'empty value produces no clause' => [
+                '',
+                '',
+            ],
+            'numeric class code is kept' => [
+                '3',
+                ' and c.size_class = 3',
+            ],
+            'zero padded class code is normalised to integer' => [
+                '01',
+                ' and c.size_class = 1',
+            ],
+            'union based sql injection collapses to integer' => [
+                '0 union select 99999999,1 order by 1 desc',
+                ' and c.size_class = 0',
+            ],
+            'boolean based sql injection collapses to integer' => [
+                '1 or 1',
+                ' and c.size_class = 1',
+            ],
+            'injection with denylist characters collapses to integer' => [
+                '1) union select password from be_users -- ',
+                ' and c.size_class = 1',
+            ],
+        ];
+    }
+
+    #[DataProvider('sizeAndRevenueClassDataProvider')]
+    public function testExtendWhereClauseWithFilterSizeClassIsNotInjectable(
+        string $sizeClass,
+        string $expectedSql
+    ): void {
+        $filter = new FilterDto();
+        $filter->setSizeClass($sizeClass);
+        self::assertSame(
+            $expectedSql,
+            $this->repository->callExtendWhereClauseWithFilterSizeClass($filter, 'c')
+        );
+    }
+
+    #[DataProvider('sizeAndRevenueClassDataProvider')]
+    public function testExtendWhereClauseWithFilterRevenueClassIsNotInjectable(
+        string $revenueClass,
+        string $expectedSql
+    ): void {
+        $filter = new FilterDto();
+        $filter->setRevenueClass($revenueClass);
+        self::assertSame(
+            str_replace('size_class', 'revenue_class', $expectedSql),
+            $this->repository->callExtendWhereClauseWithFilterRevenueClass($filter, 'c')
+        );
+    }
+}

--- a/Tests/Unit/Fixtures/Domain/Repository/AbstractRepositoryFixture.php
+++ b/Tests/Unit/Fixtures/Domain/Repository/AbstractRepositoryFixture.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace In2code\Lux\Tests\Unit\Fixtures\Domain\Repository;
+
+use In2code\Lux\Domain\Model\Transfer\FilterDto;
+use In2code\Lux\Domain\Repository\AbstractRepository;
+
+/**
+ * Exposes the protected filter where-clause builders of AbstractRepository for unit testing.
+ *
+ * The empty constructor bypasses the Extbase Repository constructor so the pure string-building
+ * methods can be exercised without a database connection.
+ */
+class AbstractRepositoryFixture extends AbstractRepository
+{
+    public function __construct()
+    {
+    }
+
+    public function callExtendWhereClauseWithFilterSizeClass(FilterDto $filter, string $table = ''): string
+    {
+        return $this->extendWhereClauseWithFilterSizeClass($filter, $table);
+    }
+
+    public function callExtendWhereClauseWithFilterRevenueClass(FilterDto $filter, string $table = ''): string
+    {
+        return $this->extendWhereClauseWithFilterRevenueClass($filter, $table);
+    }
+}


### PR DESCRIPTION
[Claude Code]

## Problem
`FilterDto::getSizeClass()` und `getRevenueClass()` werden in `AbstractRepository` **unquotiert** in rohes SQL eingefügt (Company-/Pagevisit-Filter). Die Werte durchlaufen nur die Denylist `StringUtility::sanitizeString()`, die Leerzeichen, Kommas, Ziffern und SQL-Schlüsselwörter durchlässt.

## Fix
Beide Werte an der Konkatenationsstelle nach `int` casten – analog zum bestehenden `branch_code`. Der Filter enthält ausschließlich numerische Klassen-Codes, das Verhalten für legitime Eingaben bleibt unverändert.

## Tests
Neuer `AbstractRepositoryTest` belegt, dass die Fragmente nicht mehr injizierbar sind. Unit-Suite grün (203 Tests), php-cs-fixer sauber.